### PR TITLE
Fix typo

### DIFF
--- a/kogpt2/model/gpt.py
+++ b/kogpt2/model/gpt.py
@@ -367,7 +367,7 @@ def gpt2_345m(dataset_name=None, vocab=None, pretrained=True, ctx=mx.cpu(),
     """Generic GPT-2 model.
 
     The number of layers (L) is 24, number of units (H) is 1024, and the
-    number of self-attention heads (A) is 24.
+    number of self-attention heads (A) is 16.
 
     Parameters
     ----------


### PR DESCRIPTION
As described in gpt2_345m_hparams, I think the number of self-attention head (line 370) should be 16, not 24.