### PR TITLE
Fix typo in license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 Modified MIT License
 
-Software Copyright (c) 2020 OpenAI, HugginFace Inc. team. gluon-nlp and SKT-AIX
+Software Copyright (c) 2020 OpenAI, HuggingFace Inc. team. gluon-nlp and SKT-AIX
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 associated documentation files (the "Software"), to deal in the Software without restriction,


### PR DESCRIPTION
As the license is legally binding, the parties of interest should not have spelling errors.