### PR TITLE
Fix typo in README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 ```python
 > from transformers import PreTrainedTokenizerFast
 > tokenizer = PreTrainedTokenizerFast.from_pretrained("skt/kogpt2-base-v2",
-  bos_token='</s>', eos_token='</s>', unk_token='<unk>',
+  bos_token='<s>', eos_token='</s>', unk_token='<unk>',
   pad_token='<pad>', mask_token='<mask>') 
 > tokenizer.tokenize("안녕하세요. 한국어 GPT-2 입니다.😤:)l^o")
 ['▁안녕', '하', '세', '요.', '▁한국어', '▁G', 'P', 'T', '-2', '▁입', '니다.', '😤', ':)', 'l^o']


### PR DESCRIPTION
예제 
```python
> from transformers import PreTrainedTokenizerFast
> tokenizer = PreTrainedTokenizerFast.from_pretrained("skt/kogpt2-base-v2",
  bos_token='</s>', eos_token='</s>', unk_token='<unk>',
  pad_token='<pad>', mask_token='<mask>') 
> tokenizer.tokenize("안녕하세요. 한국어 GPT-2 입니다.😤:)l^o")
['▁안녕', '하', '세', '요.', '▁한국어', '▁G', 'P', 'T', '-2', '▁입', '니다.', '😤', ':)', 'l^o']
```
부분에서 bos_token과 eos_token이 같이 <\/s>로 표기되어 있던 것을 수정했습니다.